### PR TITLE
Fix assert-url when using inside an app on a suburl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Sinatra plugin that allows authentication against the letsauth prototype, the successor for [Persona](https://login.persona.org/about). Like Persona, this lets you verify the email identity of a user.
+Sinatra plugin that allows authentication against portier, the successor for [Persona](https://login.persona.org/about). Like Persona, this lets you verify the email identity of a user.
 
-To be drop-in replacement, the code keeps using the browserid namespace.
+To be a drop-in replacement, the code keeps using the browserid namespace.
 
 ---
 
-To learn more, [read aboutletsauth](https://github.com/letsauth/letsauth.github.io).
+To learn more, [read about portier](https://portier.github.io/).
 
 Note that logins are not done from within a form on your site -- you provide a login form, and that will start up the login flow and redirect back to your main page.
 
@@ -48,12 +48,6 @@ example app, run <tt>rackup -p $PORT</tt> in the example directory.
 Available sinatra settings:
 
  * <tt>:browserid_url</tt>: If you're using an alternate auth provider
-  other than https://browserid.org
+  other than https://broker.portier.io
  * <tt>:browserid_login_url</tt>: URL users get redirected to when the
   <tt>authorize!</tt> helper is called and a user is not logged in
-
-
-TODO:
-
- * better error handling
- * Signature checking, key caching

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-Sinatra plugin that allows authentication against [BrowserID](https://browserid.org/). BrowserID lets you verify the email identity of a user.
+Sinatra plugin that allows authentication against the letsauth prototype, the successor for [Persona](https://login.persona.org/about). Like Persona, this lets you verify the email identity of a user.
 
-To learn more, see how it works [from a users perspective](https://browserid.org/about) and [from a developers perspective](https://github.com/mozilla/browserid/wiki/How-to-Use-BrowserID-on-Your-Site).
+To be drop-in replacement, the code keeps using the browserid namespace.
 
-Note that BrowserID logins are not done from within a form on your site -- you provide a login button, and that will start up the BrowserID login flow (either via a pop-up or an in-browser widget).
+---
+
+To learn more, [read aboutletsauth](https://github.com/letsauth/letsauth.github.io).
+
+Note that logins are not done from within a form on your site -- you provide a login form, and that will start up the login flow and redirect back to your main page.
 
 How to get started:
 
@@ -13,7 +17,6 @@ require 'sinatra/browserid'
 module MyApp < Sinatra::Base
     register Sinatra::BrowserID
 
-    set :browserid_login_button, :orange
     set :sessions, true
 
     get '/'
@@ -44,16 +47,13 @@ example app, run <tt>rackup -p $PORT</tt> in the example directory.
 
 Available sinatra settings:
 
-* <tt>:browserid_login_button</tt>: set to a color (:orange, :red, :blue,
-  :green, :grey) or an image URL
-* <tt>:browserid_server</tt>: If you're using an alternate auth provider
+ * <tt>:browserid_url</tt>: If you're using an alternate auth provider
   other than https://browserid.org
-* <tt>:browserid_login_url</tt>: URL users get redirected to when the
+ * <tt>:browserid_login_url</tt>: URL users get redirected to when the
   <tt>authorize!</tt> helper is called and a user is not logged in
 
 
-Still TODO:
+TODO:
 
-* better error handling
-* local assertion verification (eliminate callback)
-
+ * better error handling
+ * Signature checking, key caching

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
-require "json"
-require "net/https"
+require "open-uri"
+require 'json/jwt'
+require 'json/jwk'
 require "sinatra/base"
 require 'sinatra/browserid/helpers'
 require 'sinatra/browserid/template'
@@ -9,51 +10,47 @@ require 'sinatra/browserid/template'
 # This module provides an interface to verify a users email address
 # with browserid.org.
 module Sinatra
-  module BrowserID
-    def self.registered(app)
-      app.helpers BrowserID::Helpers
+    module BrowserID
+        def self.registered(app)
+            app.helpers BrowserID::Helpers
 
-      app.set :browserid_url, "https://login.persona.org"
-      app.set :browserid_login_button, :red
-      app.set :browserid_login_url, "/_browserid_login"
+            app.set :browserid_url, "https://laoidc.herokuapp.com"
+            app.set :browserid_login_button, :red
+            app.set :browserid_login_url, "/_browserid_login"
 
-      app.get '/_browserid_login' do
-        # TODO(petef): render a page that initiates login without
-        # waiting for a user click.
-        render_login_button
-      end
+            app.get '/_browserid_login' do
+                # TODO(petef): render a page that initiates login without
+                # waiting for a user click.
+                render_login_button
+            end
 
-      app.post '/_browserid_assert' do
-        # TODO(petef): do verification locally, without a callback
-        audience = request.host_with_port
-        bid_uri = URI.parse(settings.browserid_url)
-        http = Net::HTTP.new(bid_uri.host, bid_uri.port)
-        http.use_ssl = true
-        data = {
-          "assertion" => params[:assertion],
-          "audience" => audience,
-        }
-        data_str = data.collect { |k, v| "#{k}=#{v}" }.join("&")
-        res = http.post("/verify", data_str)
+          app.post '/_browserid_assert' do
+              begin
+                  # 3. Server checks signature
+                  # for that, fetch the public key from the LA instance (TODO: Do that beforehand for trusted instances, and generally cache the key)
+                  public_key_jwks = URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read
+                  public_key = JSON::JWK.new(public_key_jwks)
 
-        if res.code =~ /^2\d{2}$/
-          verify = ::JSON.parse(res.body)
-        else
-          return
-        end
-
-        if verify["status"] != "okay"
-          $stderr.puts "status was not OK. #{verify.inspect}"
-          return
-        end
-
-        session[:browserid_email] = verify["email"]
-        session[:browserid_expires] = verify["expires"].to_f / 1000
-
-        redirect params[:redirect] || "/"
-      end
-    end # def self.registered
-  end # module BrowserID
-  register BrowserID
+                  # TODO: we are skipping verification here, because the JWT gem is throwing an error, calling verify! on a string, which of course does not have this method. This is possibly a bug in the JWT module and needs to be fixed, or signature verification done manually
+                  id_token = JSON::JWT.decode params[:id_token], :skip_verification
+                  # 4. Needs to make sure token is still valid
+                  if (# id_token.verify! public_key  
+                      id_token[:iss] == settings.browserid_url &&
+                      id_token[:aud] == request.base_url.chomp('/') &&        
+                      # id_token[:sub].present? &&  TODO: Decide whether we really can skip these two tests
+                      # id_token[:nonce] == expected_nonce &&
+                      id_token[:exp] > Time.now.to_i)
+                          session[:browserid_email] = id_token[:email_verified]
+                          redirect "/"
+                  end
+              rescue OpenURI::HTTPError => e
+                  puts "could not validate token: " + e.to_s
+              end
+              halt 403
+              
+            end
+        end # def self.registered
+    end # module BrowserID
+    register BrowserID
 end # module Sinatra
 

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -29,7 +29,7 @@ module Sinatra
               begin
                   # 3. Server checks signature
                   # for that, fetch the public key from the LA instance (TODO: Do that beforehand for trusted instances, and generally cache the key)
-                  public_key_jwks = JSON.parse(URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read)
+                  public_key_jwks = ::JSON.parse(URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read)
                   public_key = OpenSSL::PKey::RSA.new
                   public_key.e = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["e"]), 2 
                   public_key.n = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["n"]), 2

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -40,8 +40,10 @@ module Sinatra
                   if (id_token["iss"] == settings.browserid_url &&
                       id_token["aud"] == request.base_url.chomp('/') &&        
                       id_token["exp"] > Time.now.to_i &&
-                      id_token["email_verified"])
+                      id_token["email_verified"] &&
+                      id_token["nonce"] == session[:nonce])
                           session[:browserid_email] = id_token["email"]
+                          session.delete(:nonce)
                           if session['redirect_url']
                             redirect session['redirect_url']
                           else

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -13,7 +13,7 @@ module Sinatra
     def self.registered(app)
       app.helpers BrowserID::Helpers
 
-      app.set :browserid_url, "https://browserid.org"
+      app.set :browserid_url, "https://login.persona.org"
       app.set :browserid_login_button, :red
       app.set :browserid_login_url, "/_browserid_login"
 

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -42,7 +42,11 @@ module Sinatra
                       id_token["exp"] > Time.now.to_i &&
                       id_token["email_verified"])
                           session[:browserid_email] = id_token["email"]
-                          redirect "/"
+                          if session['redirect_url']
+                            redirect session['redirect_url']
+                          else
+                            redirect "/"
+                          end
                   end
               rescue OpenURI::HTTPError => e
                   puts "could not validate token: " + e.to_s

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -15,7 +15,7 @@ module Sinatra
         def self.registered(app)
             app.helpers BrowserID::Helpers
 
-            app.set :browserid_url, "https://laoidc.herokuapp.com"
+            app.set :browserid_url, "https://broker.portier.io"
             app.set :browserid_login_button, :red
             app.set :browserid_login_url, "/_browserid_login"
 

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 
 require "open-uri"
-require 'json/jwt'
-require 'json/jwk'
+require 'json'
+require 'url_safe_base64'
+require 'jwt'
 require "sinatra/base"
 require 'sinatra/browserid/helpers'
 require 'sinatra/browserid/template'
@@ -28,19 +29,19 @@ module Sinatra
               begin
                   # 3. Server checks signature
                   # for that, fetch the public key from the LA instance (TODO: Do that beforehand for trusted instances, and generally cache the key)
-                  public_key_jwks = URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read
-                  public_key = JSON::JWK.new(public_key_jwks)
-
-                  # TODO: we are skipping verification here, because the JWT gem is throwing an error, calling verify! on a string, which of course does not have this method. This is possibly a bug in the JWT module and needs to be fixed, or signature verification done manually
-                  id_token = JSON::JWT.decode params[:id_token], :skip_verification
+                  public_key_jwks = JSON.parse(URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read)
+                  public_key = OpenSSL::PKey::RSA.new
+                  public_key.e = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["e"]), 2 
+                  public_key.n = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["n"]), 2
+                  
+                  id_token = JWT.decode params[:id_token], public_key, true, { :algorithm => 'RS256' }
+                  id_token = id_token[0]
                   # 4. Needs to make sure token is still valid
-                  if (# id_token.verify! public_key  
-                      id_token[:iss] == settings.browserid_url &&
-                      id_token[:aud] == request.base_url.chomp('/') &&        
-                      # id_token[:sub].present? &&  TODO: Decide whether we really can skip these two tests
-                      # id_token[:nonce] == expected_nonce &&
-                      id_token[:exp] > Time.now.to_i)
-                          session[:browserid_email] = id_token[:email_verified]
+                  if (id_token["iss"] == settings.browserid_url &&
+                      id_token["aud"] == request.base_url.chomp('/') &&        
+                      id_token["exp"] > Time.now.to_i &&
+                      id_token["email_verified"])
+                          session[:browserid_email] = id_token["email"]
                           redirect "/"
                   end
               rescue OpenURI::HTTPError => e

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -29,7 +29,7 @@ module Sinatra
               begin
                   # 3. Server checks signature
                   # for that, fetch the public key from the LA instance (TODO: Do that beforehand for trusted instances, and generally cache the key)
-                  public_key_jwks = ::JSON.parse(URI.parse(URI.escape(settings.browserid_url + '/jwks.json')).read)
+                  public_key_jwks = ::JSON.parse(URI.parse(URI.escape(settings.browserid_url + '/keys.json')).read)
                   public_key = OpenSSL::PKey::RSA.new
                   public_key.e = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["e"]), 2 
                   public_key.n = OpenSSL::BN.new UrlSafeBase64.decode64(public_key_jwks["keys"][0]["n"]), 2

--- a/lib/sinatra/browserid/helpers.rb
+++ b/lib/sinatra/browserid/helpers.rb
@@ -38,6 +38,11 @@ module Sinatra
         redirect_url ||= request.url
         session['redirect_url'] = redirect_url
 
+        nonce = session[:nonce]
+        unless nonce
+          session[:nonce] = nonce = SecureRandom.base64
+        end
+
         template = ERB.new(Templates::LOGIN_BUTTON)
         template.result(binding)
       end

--- a/lib/sinatra/browserid/helpers.rb
+++ b/lib/sinatra/browserid/helpers.rb
@@ -27,26 +27,16 @@ module Sinatra
         session[:browserid_email]
       end
 
-      # Returns the HTML to render the BrowserID login button.
+      # Returns the HTML to render the Persona login form.
       # Optionally takes a URL parameter for where the user should
-      # be redirected to after the assert POST back.  You can
-      # customize the button image by setting the Sinatra option
-      # <tt>:browserid_login_button</tt> to a color (:orange,
-      # :red, :blue, :green, :grey) or an actual URL.
+      # be redirected to after the assert POST back.
       def render_login_button(redirect_url = nil)
-        case settings.browserid_login_button
-        when :orange, :red, :blue, :green, :grey
-          button_url = "#{settings.browserid_url}/i/sign_in_" \
-                       "#{settings.browserid_login_button.to_s}.png"
-        else
-          button_url = settings.browserid_login_button
-        end
-
         if session[:authorize_redirect_url]
           redirect_url = session[:authorize_redirect_url]
           session[:authorize_redirect_url] = nil
         end
         redirect_url ||= request.url
+        session['redirect_url'] = redirect_url
 
         template = ERB.new(Templates::LOGIN_BUTTON)
         template.result(binding)

--- a/lib/sinatra/browserid/template.rb
+++ b/lib/sinatra/browserid/template.rb
@@ -8,6 +8,7 @@ module Sinatra
       <input type=hidden name=response_type value="id_token" />
       <input type=hidden name=client_id value="<%= request.base_url.chomp('/') %>" />
       <input type=hidden name=redirect_uri value="<%= url '/_browserid_assert' %>" />
+      <input type=hidden name=nonce value="<%= nonce %>" />
       <input type=submit value="Log In" />
     </form>
 EOF

--- a/lib/sinatra/browserid/template.rb
+++ b/lib/sinatra/browserid/template.rb
@@ -16,7 +16,7 @@ navigator.id.getVerifiedEmail(function(assertion) {
 }
 </script>
 
-<form name="_browserid_assert" action="/_browserid_assert" method="post">
+<form name="_browserid_assert" action="<%= url '/_browserid_assert' %>" method="post">
 <input type="hidden" name="redirect" value="<%= redirect_url %>">
 <input type="hidden" name="assertion" value="">
 </form>

--- a/lib/sinatra/browserid/template.rb
+++ b/lib/sinatra/browserid/template.rb
@@ -6,6 +6,7 @@ module Sinatra
       <input type=email name=login_hint placeholder="you@example.com" />
       <input type=hidden name=scope value="openid email" />
       <input type=hidden name=response_type value="id_token" />
+      <input type=hidden name=response_mode value="form_post" />
       <input type=hidden name=client_id value="<%= request.base_url.chomp('/') %>" />
       <input type=hidden name=redirect_uri value="<%= url '/_browserid_assert' %>" />
       <input type=hidden name=nonce value="<%= nonce %>" />

--- a/lib/sinatra/browserid/template.rb
+++ b/lib/sinatra/browserid/template.rb
@@ -1,29 +1,17 @@
 module Sinatra
-  module BrowserID
-    module Templates
-      LOGIN_BUTTON = <<-EOF
-<script src="<%= settings.browserid_url %>/include.js" type="text/javascript"></script>
-<script type="text/javascript">
-function _browserid_login() {
-navigator.id.getVerifiedEmail(function(assertion) {
-    if (assertion) {
-        document.forms._browserid_assert.assertion.value = assertion;
-        document.forms._browserid_assert.submit();
-    } else {
-        // TODO: handle failure case?
-    }
-});
-}
-</script>
-
-<form name="_browserid_assert" action="<%= url '/_browserid_assert' %>" method="post">
-<input type="hidden" name="redirect" value="<%= redirect_url %>">
-<input type="hidden" name="assertion" value="">
-</form>
-
-<a href="#"><img src="<%= button_url %>" id="browserid_login_button" border=0 onClick="_browserid_login()" /></a>
+    module BrowserID
+        module Templates
+            LOGIN_BUTTON = <<-EOF
+<form action="<%= settings.browserid_url %>/auth" method="POST">
+      <input type=email name=login_hint placeholder="you@example.com" />
+      <input type=hidden name=scope value="openid email" />
+      <input type=hidden name=response_type value="id_token" />
+      <input type=hidden name=client_id value="<%= request.base_url.chomp('/') %>" />
+      <input type=hidden name=redirect_uri value="<%= url '/_browserid_assert' %>" />
+      <input type=submit value="Log In" />
+    </form>
 EOF
+        end
     end
-  end
 end
 

--- a/lib/sinatra/portier.rb
+++ b/lib/sinatra/portier.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+require __dir__ + '/browserid.rb'

--- a/sinatra-browserid.gemspec
+++ b/sinatra-browserid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "sinatra-browserid"
-  s.version = "0.3.2"
+  s.version = "1.0.0"
 
   s.authors = ["Pete Fritchman"]
   s.email = ["petef@databits.net"]
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.summary = "Sinatra extension for user authentication with browserid.org"
 
   s.add_dependency("sinatra", ">= 1.1.0")
+  s.add_dependency("json-jwt", ">= 1.5.0")
 end

--- a/sinatra-browserid.gemspec
+++ b/sinatra-browserid.gemspec
@@ -1,17 +1,18 @@
 Gem::Specification.new do |s|
   s.name = "sinatra-browserid"
-  s.version = "1.0.0"
+  s.version = "1.1.0"
 
-  s.authors = ["Pete Fritchman"]
-  s.email = ["petef@databits.net"]
+  s.authors = ["Pete Fritchman", "Malte Paskuda"]
+  s.email = ["malte@paskuda.biz"]
   s.files = ["README.md", "lib/sinatra/browserid.rb", "example/app.rb",
              "example/config.ru", "example/views/index.erb"]
   s.has_rdoc = true
   s.homepage = "https://github.com/fetep/sinatra-browserid"
   s.rdoc_options = ["--inline-source"]
   s.require_paths = ["lib"]
-  s.summary = "Sinatra extension for user authentication with browserid.org"
+  s.summary = "Sinatra extension for user authentication with letsauth"
 
   s.add_dependency("sinatra", ">= 1.1.0")
-  s.add_dependency("json-jwt", ">= 1.5.0")
+  s.add_dependency("jwt", ">= 1.5.4")
+  s.add_dependency("url_safe_base64", ">= 0.2.2")
 end

--- a/sinatra-browserid.gemspec
+++ b/sinatra-browserid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "sinatra-browserid"
-  s.version = "0.3"
+  s.version = "0.3.1"
 
   s.authors = ["Pete Fritchman"]
   s.email = ["petef@databits.net"]

--- a/sinatra-browserid.gemspec
+++ b/sinatra-browserid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "sinatra-browserid"
-  s.version = "0.3.1"
+  s.version = "0.3.2"
 
   s.authors = ["Pete Fritchman"]
   s.email = ["petef@databits.net"]

--- a/sinatra-portier.gemspec
+++ b/sinatra-portier.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name = "sinatra-browserid"
+  s.name = "sinatra-portier"
   s.version = "1.1.0"
 
   s.authors = ["Pete Fritchman", "Malte Paskuda"]
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
   s.files = ["README.md", "lib/sinatra/browserid.rb", "example/app.rb",
              "example/config.ru", "example/views/index.erb"]
   s.has_rdoc = true
-  s.homepage = "https://github.com/fetep/sinatra-browserid"
+  s.homepage = "https://github.com/onli/sinatra-portier"
   s.rdoc_options = ["--inline-source"]
   s.require_paths = ["lib"]
-  s.summary = "Sinatra extension for user authentication with letsauth"
+  s.summary = "Sinatra extension for user authentication with portier"
 
   s.add_dependency("sinatra", ">= 1.1.0")
   s.add_dependency("jwt", ">= 1.5.4")

--- a/sinatra-portier.gemspec
+++ b/sinatra-portier.gemspec
@@ -1,11 +1,13 @@
 Gem::Specification.new do |s|
   s.name = "sinatra-portier"
-  s.version = "1.1.0"
+  s.version = "1.1.2"
 
   s.authors = ["Pete Fritchman", "Malte Paskuda"]
   s.email = ["malte@paskuda.biz"]
   s.files = ["README.md", "lib/sinatra/browserid.rb", "example/app.rb",
-             "example/config.ru", "example/views/index.erb"]
+             "example/config.ru", "example/views/index.erb",
+             "lib/sinatra/browserid/helpers.rb", "lib/sinatra/browserid/template.rb",
+             "lib/sinatra/portier.rb"]
   s.has_rdoc = true
   s.homepage = "https://github.com/onli/sinatra-portier"
   s.rdoc_options = ["--inline-source"]


### PR DESCRIPTION
This refers to https://github.com/fetep/sinatra-browserid/issues/5. If the sinatra app is not listening on /, but rather mapped to a /suburl/ as its root, the generated link for _browserid_assert did not work. Using the url-helper seems to fix that.
